### PR TITLE
Add Git pre-commit hook instructions

### DIFF
--- a/git-pre-commit-hook.markdown
+++ b/git-pre-commit-hook.markdown
@@ -1,0 +1,17 @@
+---
+layout: scalastyle
+title: "Scalastyle - Git pre-commit hook"
+---
+
+### Running scalastyle with overcommit
+
+[overcommit](https://github.com/brigade/overcommit) is a fully configurable and
+extendable Git hook manager that includes out-of-the-box support for running
+scalastyle as a Git pre-commit hook.
+
+To configure overcommit to run scalastyle, include the following in your
+`.overcommit.yml` file:
+
+    PreCommt:
+      Scalastyle:
+        enabled: true

--- a/index.markdown
+++ b/index.markdown
@@ -16,6 +16,7 @@ There are several ways of using it:
 
  * [Maven Plugin](maven.html)
  * [Eclipse plugin (for 4.2 Juno and 4.3 Kepler and 4.4 Luna)](eclipse-index.html)
+ * [Git pre-commit hook](git-pre-commit-hook.html)
  * [SBT plugin](sbt.html)
  * [Command line](command-line.html)
  * [Gradle Plugin](https://github.com/MansurAshraf/gradle-scalastyle-plugin)


### PR DESCRIPTION
overcommit is a fully configurable and extendable Git hook manager that
includes out-of-the-box support for running scalastyle as a Git
pre-commit hook.