### PR TITLE
sbt's default resolvers resolve the plugin just fine

### DIFF
--- a/custom-rules.markdown
+++ b/custom-rules.markdown
@@ -59,8 +59,6 @@ sbt is easy. You can add the jar as a normal library dependency into your `proje
     addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
     
     libraryDependencies += "org.ext" %% "nofoobarchecker" % "1.0.0"
-    
-    resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 
 Or just copy the custom rules into your `project/lib` directory, and you should be good to go. Note that for sbt 0.13, you'll need to use the **2.10** version of scalastyle to compile your custom rules.
 

--- a/sbt.markdown
+++ b/sbt.markdown
@@ -13,11 +13,9 @@ The repository for the Scalastyle SBT plugin is: [Sonatype : https://oss.sonatyp
 
 ### Setup
 
-Add the following lines to `project/plugins.sbt`
+Add the following line to `project/plugins.sbt`
 
     addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
-
-    resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 
 ### Usage
 


### PR DESCRIPTION
perhaps this was necessary at some point in the past...?
I don't think it is now.