### PR TITLE
update typo in Intellij description

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -19,7 +19,7 @@ There are several ways of using it:
  * [SBT plugin](sbt.html)
  * [Command line](command-line.html)
  * [Gradle Plugin](https://github.com/ngbinh/gradle-scalastyle-plugin)
- * Intellij - You can enable scalastyle in Intellij by selecting Settings->Editor->Inspections, then searching for Scala style inspections.
+ * Intellij - You can enable scalastyle in Intellij by selecting Preferences->Editor->Inspections, then searching for Scala style inspections.
  * [Git pre-commit hook](git-pre-commit-hook.html)
 
 And you'll need a [configuration](configuration.html). If you have your own custom rules, then see [custom rules](custom-rules.html)


### PR DESCRIPTION
On the homepage, the Intellij installation description says to go to "settings" but it's actually under "preferences."

FYI - using the Intellij Community Edition.