### PR TITLE
Fix typo in example configuration for file.NewLineAtEofChecker

### DIFF
--- a/rules-0.1.0.markdown
+++ b/rules-0.1.0.markdown
@@ -90,7 +90,7 @@ Some version control systems don't cope well with files which don't end with a n
 No parameters
 
 ### Example configuration
-<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewlineAtEofChecker&quot; level=&quot;warning&quot;&gt;&lt;/check&gt;</pre>
+<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewLineAtEofChecker&quot; level=&quot;warning&quot;&gt;&lt;/check&gt;</pre>
 ### org.scalastyle.file.NoNewLineAtEofChecker - Checks that a file does not end with a newline character
 
  * id - no.newline.at.eof

--- a/rules-0.2.0.markdown
+++ b/rules-0.2.0.markdown
@@ -90,7 +90,7 @@ Some version control systems don't cope well with files which don't end with a n
 No parameters
 
 ### Example configuration
-<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewlineAtEofChecker&quot; level=&quot;warning&quot;&gt;&lt;/check&gt;</pre>
+<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewLineAtEofChecker&quot; level=&quot;warning&quot;&gt;&lt;/check&gt;</pre>
 ### org.scalastyle.file.NoNewLineAtEofChecker - Checks that a file does not end with a newline character
 
  * id - no.newline.at.eof

--- a/rules-0.3.0.markdown
+++ b/rules-0.3.0.markdown
@@ -90,7 +90,7 @@ Some version control systems don't cope well with files which don't end with a n
 No parameters
 
 ### Example configuration
-<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewlineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
+<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewLineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
 ### org.scalastyle.file.NoNewLineAtEofChecker - Checks that a file does not end with a newline character
 
  * id - no.newline.at.eof

--- a/rules-0.4.0.markdown
+++ b/rules-0.4.0.markdown
@@ -103,7 +103,7 @@ Some version control systems don't cope well with files which don't end with a n
 No parameters
 
 ### Example configuration
-<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewlineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
+<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewLineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
 ### org.scalastyle.file.NoNewLineAtEofChecker - Checks that a file does not end with a newline character
 
  * id - no.newline.at.eof

--- a/rules-0.5.0.markdown
+++ b/rules-0.5.0.markdown
@@ -111,7 +111,7 @@ Some version control systems don't cope well with files which don't end with a n
 No parameters
 
 ### Example configuration
-<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewlineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
+<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewLineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
 ### org.scalastyle.file.NoNewLineAtEofChecker - Checks that a file does not end with a newline character
 
  * id - no.newline.at.eof

--- a/rules-0.6.0.markdown
+++ b/rules-0.6.0.markdown
@@ -201,7 +201,7 @@ Some version control systems don't cope well with files which don't end with a n
 No parameters
 
 ### Example configuration
-<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewlineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
+<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewLineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
 <a name="org_scalastyle_file_NoNewLineAtEofChecker" />
 ### org.scalastyle.file.NoNewLineAtEofChecker - Checks that a file does not end with a newline character
 

--- a/rules-0.7.0.markdown
+++ b/rules-0.7.0.markdown
@@ -213,7 +213,7 @@ Some version control systems don't cope well with files which don't end with a n
 No parameters
 
 ### Example configuration
-<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewlineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
+<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewLineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
 <a name="org_scalastyle_file_NoNewLineAtEofChecker" />
 ### org.scalastyle.file.NoNewLineAtEofChecker - Checks that a file does not end with a newline character
 

--- a/rules-0.8.0.markdown
+++ b/rules-0.8.0.markdown
@@ -221,7 +221,7 @@ Some version control systems don't cope well with files which don't end with a n
 No parameters
 
 ### Example configuration
-<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewlineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
+<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewLineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
 <a name="org_scalastyle_file_NoNewLineAtEofChecker" />
 ### org.scalastyle.file.NoNewLineAtEofChecker - Checks that a file does not end with a newline character
 

--- a/rules-dev.markdown
+++ b/rules-dev.markdown
@@ -221,7 +221,7 @@ Some version control systems don't cope well with files which don't end with a n
 No parameters
 
 ### Example configuration
-<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewlineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
+<pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.file.NewLineAtEofChecker&quot; level=&quot;warning&quot;/&gt;</pre>
 <a name="org_scalastyle_file_NoNewLineAtEofChecker" />
 ### org.scalastyle.file.NoNewLineAtEofChecker - Checks that a file does not end with a newline character
 


### PR DESCRIPTION
Found this while configuring scalastyle for a project. I copied directly from the example and was wondering why it didn't work. Cause is due to the 'L' not being uppercase in NewLine