### PR TITLE
Add option to NonASCIICharacterChecker to allow international characters in string literals #283

### DIFF
--- a/release-notes.markdown
+++ b/release-notes.markdown
@@ -3,6 +3,13 @@ layout: scalastyle
 title: "Scalastyle - Release notes"
 ---
 
+Version 1.1.0
+=============
+
+Additions / bugfixes:
+
+ * Fix: #283 Add a NonASCIICharacterChecker option to allow international characters in string literals
+
 Version 1.0.0
 =============
 

--- a/rules-dev.markdown
+++ b/rules-dev.markdown
@@ -1091,7 +1091,18 @@ Scala allows unicode characters as operators and some editors misbehave when the
             To fix it, replace the (unicode operator)⇒ with =>.
 
 #### Parameters
-No parameters
+<table width="80%">
+  <tr><th>Parameter</th><th>Description</th><th>Type</th><th>Default Value</th></tr>
+  <tr>
+    <td>allowNonAsciiScriptsInStringLiterals</td>
+    <td>
+      Allow scripts other than ASCII
+      (as defined by the regex `[\p{Alnum}\p{Punct}\p{Sc}\p{Space}]`) in string literals
+    </td>
+    <td>boolean</td>
+    <td>false</td>
+  </tr>
+</table>
 
 ### Example configuration
 <pre>&lt;check enabled=&quot;true&quot; class=&quot;org.scalastyle.scalariform.NonASCIICharacterChecker&quot; level=&quot;warning&quot;/&gt;</pre>


### PR DESCRIPTION
Companion to https://github.com/scalastyle/scalastyle/pull/284