### PR TITLE
Suggest that sbt test depends on compile:scalastyle as well

### DIFF
--- a/sbt.markdown
+++ b/sbt.markdown
@@ -87,17 +87,24 @@ This has exactly the same output as the scalastyle command, except that the gene
 
 ### Running scalastyle as part of another task
 
-You can also have your scalastyle checks automatically run as part of another task:
+You can also have your scalastyle checks automatically run as part of another task.
 
-    // Create a default Scala style task to run with tests
+For example, you can run scalastyle on both the main and test sources during testing, that is, running `sbt test` will also run both the `compile:scalastyle` and `test:scalastyle` tasks:
+
+    // Create default Scala style tasks to run with tests
     lazy val testScalastyle = taskKey[Unit]("testScalastyle")
+    lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
 
     // scalastyle >= 0.9.0
     testScalastyle := scalastyle.in(Test).toTask("").value
+    compileScalastyle := scalastyle.in(Compile).toTask("").value
     // scalastyle <= 0.8.0
     testScalastyle := org.scalastyle.sbt.ScalastylePlugin.scalastyle.in(Test).toTask("").value
+    compileScalastyle := org.scalastyle.sbt.ScalastylePlugin.scalastyle.in(Compile).toTask("").value
 
     (test in Test) := ((test in Test) dependsOn testScalastyle).value
+    (test in Test) := ((test in Test) dependsOn compileScalastyle).value
+
 
 or as part of the compile task:
 


### PR DESCRIPTION
This expands the documentation to explicitly have the example code make `test` depend on `compile:scalastyle`, that is, make `sbt test` also run scalastyle on the main code.

This is designed to be the common case, and a slightly "safer" default. It seems like many people wanting to have scalastyle as part of their tests will want to also be testing their main code. And, as a default, people copying in the code without fully understanding it (or, maybe, without fully understanding sbt's compilation model) will have all their code checked. With the new, one only has to delete some lines to have `sbt test` only run scalastyle on the tests; with the old, one has to realise that some code needs to be added, and then add it to have `sbt test` run scalastyle on the main code. The first of those seems simpler.